### PR TITLE
decoupling rules from publicsuffixlist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,5 +40,8 @@
         "psr-4": {
             "Psl\\Tests\\": "tests/"
         }
+    },
+    "scripts": {
+        "phpunit": "phpunit --coverage-text"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,4 +25,11 @@
             <directory>./src</directory>
         </whitelist>
     </filter>
+
+    <logging>
+        <log type="junit" target="build/report.junit.xml"/>
+        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
+        <log type="coverage-text" target="build/coverage.txt"/>
+        <log type="coverage-clover" target="build/clover.xml"/>
+    </logging>
 </phpunit>

--- a/src/LabelsTrait.php
+++ b/src/LabelsTrait.php
@@ -14,23 +14,51 @@ namespace Psl;
 
 trait LabelsTrait
 {
+    /**
+     * Returns domain labels
+     *
+     * @param string $input
+     *
+     * @return string[]
+     */
     private function getLabels(string $input): array
     {
         return explode('.', $input);
     }
 
+    /**
+     * Returns domains labesl in reverse
+     *
+     * @param string $input
+     *
+     * @return string[]
+     */
     private function getLabelsReverse(string $input): array
     {
         return array_reverse($this->getLabels($input));
     }
 
+    /**
+     * Tell whether the submit domain contains more than one label
+     *
+     * @param string $input
+     *
+     * @return bool
+     */
     private function hasLabels(string $input): bool
     {
         return strpos($input, '.') !== false;
     }
 
-    private function isSingleLabelDomain(string $domain): bool
+    /**
+     * Tell whether the submitted domain is composed of a single label
+     *
+     * @param string $input
+     *
+     * @return bool
+     */
+    private function isSingleLabelDomain(string $input): bool
     {
-        return !$this->hasLabels($domain);
+        return !$this->hasLabels($input);
     }
 }

--- a/src/MatchedDomain.php
+++ b/src/MatchedDomain.php
@@ -31,6 +31,13 @@ final class MatchedDomain implements Domain
      */
     private $isValid;
 
+    /**
+     * New instance
+     *
+     * @param string|null $domain
+     * @param string|null $publicSuffix
+     * @param bool        $isValid
+     */
     public function __construct(string $domain = null, string $publicSuffix = null, bool $isValid = false)
     {
         $this->domain = $domain;
@@ -38,24 +45,36 @@ final class MatchedDomain implements Domain
         $this->isValid = $isValid;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function getDomain()
     {
         return $this->domain;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function getPublicSuffix()
     {
         return $this->publicSuffix;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function isValid(): bool
     {
         return $this->isValid;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function getRegistrableDomain()
     {
-        if ($this->hasRegistrableDomain($this->publicSuffix) === false) {
+        if (!$this->hasRegistrableDomain()) {
             return null;
         }
 
@@ -66,19 +85,26 @@ final class MatchedDomain implements Domain
         return implode('.', array_merge($additionalLabel, $publicSuffixLabels));
     }
 
-    private function hasRegistrableDomain($publicSuffix): bool
+    /**
+     * Tell whether the object contain a registrable domain
+     *
+     * @return bool
+     */
+    private function hasRegistrableDomain(): bool
     {
-        return !($publicSuffix === null || $this->domain === $publicSuffix || !$this->hasLabels($this->domain));
+        return !in_array($this->publicSuffix, [null, $this->domain], true) && $this->hasLabels($this->domain);
     }
 
+    /**
+     * Returns the additional label to generate the registrable domain
+     *
+     * @param string[] $domainLabels
+     * @param string[] $publicSuffixLabels
+     *
+     * @return string[]
+     */
     private function getAdditionalLabel($domainLabels, $publicSuffixLabels): array
     {
-        $additionalLabel = array_slice(
-            $domainLabels,
-            count($domainLabels) - count($publicSuffixLabels) - 1,
-            1
-        );
-
-        return $additionalLabel;
+        return array_slice($domainLabels, count($domainLabels) - count($publicSuffixLabels) - 1, 1);
     }
 }

--- a/src/NullDomain.php
+++ b/src/NullDomain.php
@@ -10,15 +10,12 @@ declare(strict_types=1);
  * @copyright Copyright (c) 2017 Jeremy Kendall (http://jeremykendall.net)
  * @license   http://github.com/jeremykendall/publicsuffixlist-php/blob/master/LICENSE MIT License
  */
-
-
 namespace Psl;
-
 
 class NullDomain implements Domain
 {
     /**
-     * @return string|null
+     * @inheritdoc
      */
     public function getDomain()
     {
@@ -26,7 +23,7 @@ class NullDomain implements Domain
     }
 
     /**
-     * @return string|null
+     * @inheritdoc
      */
     public function getPublicSuffix()
     {
@@ -34,18 +31,7 @@ class NullDomain implements Domain
     }
 
     /**
-     * Get registrable domain.
-     *
-     * Algorithm #7: The registered or registrable domain is the public suffix
-     * plus one additional label.
-     *
-     * This method should return null if the domain provided is a public suffix,
-     * per the test cases provided by Mozilla.
-     *
-     * @see https://publicsuffix.org/list/
-     * @see https://raw.githubusercontent.com/publicsuffix/list/master/tests/test_psl.txt
-     *
-     * @return string|null registrable domain
+     * @inheritdoc
      */
     public function getRegistrableDomain()
     {
@@ -53,19 +39,7 @@ class NullDomain implements Domain
     }
 
     /**
-     * Does the domain have a matching rule in the Public Suffix List?
-     *
-     * WARNING: "Some people use the PSL to determine what is a valid domain name
-     * and what isn't. This is dangerous, particularly in these days where new
-     * gTLDs are arriving at a rapid pace, if your software does not regularly
-     * receive PSL updates, because it will erroneously think new gTLDs are not
-     * valid. The DNS is the proper source for this information. If you must use
-     * it for this purpose, please do not bake static copies of the PSL into your
-     * software with no update mechanism."
-     *
-     * @see https://publicsuffix.org/learn/
-     *
-     * @return bool
+     * @inheritdoc
      */
     public function isValid(): bool
     {

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Public Suffix List PHP: Public Suffix List based URL parsing.
+ *
+ * @see http://github.com/jeremykendall/publicsuffixlist-php for the canonical source repository
+ *
+ * @copyright Copyright (c) 2017 Jeremy Kendall (http://jeremykendall.net)
+ * @license   http://github.com/jeremykendall/publicsuffixlist-php/blob/master/LICENSE MIT License
+ */
+namespace Psl;
+
+final class Rules
+{
+    use LabelsTrait;
+
+    /**
+     * @var array
+     */
+    private $rules;
+
+    /**
+     * New instance
+     *
+     * @param array $rules PSL ruling array
+     */
+    public function __construct(array $rules = null)
+    {
+        $this->rules = $rules ?? include dirname(__DIR__) . '/data/public-suffix-list.php';
+    }
+
+    /**
+     * Returns the public suffix info determined from the PSL rules array
+     *
+     * The returned array is composed of two value:
+     *
+     * - the fist index contains the detected public suffix or null
+     * - the second index tells whether the return public suffix is valid or not
+     *
+     * @param string $input
+     *
+     * @return array
+     */
+    public function parse(string $input): array
+    {
+        $domain = strtolower(idn_to_ascii($input, 0, INTL_IDNA_VARIANT_UTS46));
+        $matchingLabels = $this->findMatchingLabels($this->getLabelsReverse($domain));
+        if (empty($matchingLabels)) {
+            $labels = $this->getLabels($input);
+
+            return [array_pop($labels), false];
+        }
+
+        return [implode('.', array_filter($matchingLabels, 'strlen')), true];
+    }
+
+    /**
+     * Returns the matchin labels according to the PSL rules
+     *
+     * @param array $labels
+     *
+     * @return string[]
+     */
+    private function findMatchingLabels(array $labels): array
+    {
+        $matches = [];
+        $rules = $this->rules;
+        foreach ($labels as $label) {
+            if ($this->isExceptionRule($label, $rules)) {
+                break;
+            }
+
+            if ($this->isWildcardRule($rules)) {
+                array_unshift($matches, $label);
+                break;
+            }
+
+            if ($this->matchExists($label, $rules)) {
+                array_unshift($matches, $label);
+                $rules = $rules[$label];
+                continue;
+            }
+
+            // Avoids improper parsing when $domain's subdomain + public suffix ===
+            // a valid public suffix (e.g. domain 'us.example.com' and public suffix 'us.com')
+            //
+            // Added by @goodhabit in https://github.com/jeremykendall/php-domain-parser/pull/15
+            // Resolves https://github.com/jeremykendall/php-domain-parser/issues/16
+            break;
+        }
+
+        return $matches;
+    }
+
+    /**
+     * Tell whether a PSL exception rule is found
+     *
+     * @param  string $label
+     * @param  array  $rules
+     *
+     * @return bool
+     */
+    private function isExceptionRule(string $label, array $rules): bool
+    {
+        return $this->matchExists($label, $rules)
+            && array_key_exists('!', $rules[$label]);
+    }
+
+    /**
+     * Tell whether a PSL wildcard rule is found
+     *
+     * @param array $rules
+     *
+     * @return bool
+     */
+    private function isWildcardRule(array $rules): bool
+    {
+        return array_key_exists('*', $rules);
+    }
+
+    /**
+     * Tell whether a PSL rule is found for a given domain label
+     *
+     * @param string $label
+     * @param array  $rules
+     *
+     * @return bool
+     */
+    private function matchExists(string $label, array $rules): bool
+    {
+        return array_key_exists($label, $rules);
+    }
+}

--- a/src/UnmatchedDomain.php
+++ b/src/UnmatchedDomain.php
@@ -10,10 +10,7 @@ declare(strict_types=1);
  * @copyright Copyright (c) 2017 Jeremy Kendall (http://jeremykendall.net)
  * @license   http://github.com/jeremykendall/publicsuffixlist-php/blob/master/LICENSE MIT License
  */
-
-
 namespace Psl;
-
 
 class UnmatchedDomain implements Domain
 {
@@ -34,6 +31,13 @@ class UnmatchedDomain implements Domain
      */
     private $isValid;
 
+    /**
+     * New instance
+     *
+     * @param string|null $domain
+     * @param string|null $publicSuffix
+     * @param bool        $isValid
+     */
     public function __construct(string $domain = null, string $publicSuffix = null, bool $isValid = false)
     {
         $this->domain = $domain;
@@ -41,24 +45,36 @@ class UnmatchedDomain implements Domain
         $this->isValid = $isValid;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function getDomain()
     {
         return $this->domain;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function getPublicSuffix()
     {
         return $this->publicSuffix;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function isValid(): bool
     {
         return $this->isValid;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function getRegistrableDomain()
     {
-        if ($this->hasRegistrableDomain($this->publicSuffix) === false) {
+        if (!$this->hasRegistrableDomain()) {
             return null;
         }
 
@@ -69,19 +85,26 @@ class UnmatchedDomain implements Domain
         return implode('.', array_merge($additionalLabel, $publicSuffixLabels));
     }
 
-    private function hasRegistrableDomain($publicSuffix): bool
+    /**
+     * Tell whether the object contain a registrable domain
+     *
+     * @return bool
+     */
+    private function hasRegistrableDomain(): bool
     {
-        return !($publicSuffix === null || $this->domain === $publicSuffix || !$this->hasLabels($this->domain));
+        return !in_array($this->publicSuffix, [null, $this->domain], true) && $this->hasLabels($this->domain);
     }
 
+    /**
+     * Returns the additional label to generate the registrable domain
+     *
+     * @param string[] $domainLabels
+     * @param string[] $publicSuffixLabels
+     *
+     * @return string[]
+     */
     private function getAdditionalLabel($domainLabels, $publicSuffixLabels): array
     {
-        $additionalLabel = array_slice(
-            $domainLabels,
-            count($domainLabels) - count($publicSuffixLabels) - 1,
-            1
-        );
-
-        return $additionalLabel;
+        return array_slice($domainLabels, count($domainLabels) - count($publicSuffixLabels) - 1, 1);
     }
 }

--- a/tests/PublicSuffixListTest.php
+++ b/tests/PublicSuffixListTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Psl\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Psl\Domain;
 use Psl\MatchedDomain;
 use Psl\NullDomain;
 use Psl\PublicSuffixList;
@@ -36,12 +37,15 @@ class PublicSuffixListTest extends TestCase
         $domain = $this->list->query('COM');
         $this->assertFalse($domain->isValid());
         $this->assertInstanceOf(NullDomain::class, $domain);
+        $this->assertInstanceOf(Domain::class, $domain);
+        $this->assertNull($domain->getDomain());
     }
 
     public function testIsSuffixValidFalse()
     {
         $domain = $this->list->query('www.example.faketld');
         $this->assertFalse($domain->isValid());
+        $this->assertInstanceOf(Domain::class, $domain);
         $this->assertInstanceOf(UnmatchedDomain::class, $domain);
     }
 
@@ -49,13 +53,14 @@ class PublicSuffixListTest extends TestCase
     {
         $domain = $this->list->query('www.example.com');
         $this->assertTrue($domain->isValid());
+        $this->assertInstanceOf(Domain::class, $domain);
         $this->assertInstanceOf(MatchedDomain::class, $domain);
     }
 
     /**
      * @dataProvider parseDataProvider
      */
-    public function testGetRegistrableDomain($publicSuffix, $registrableDomain, $domain)
+    public function testGetRegistrableDomain($publicSuffix, $registrableDomain, $domain, $expectedDomain)
     {
         $this->assertSame($registrableDomain, $this->list->query($domain)->getRegistrableDomain());
     }
@@ -63,9 +68,42 @@ class PublicSuffixListTest extends TestCase
     /**
      * @dataProvider parseDataProvider
      */
-    public function testGetPublicSuffix($publicSuffix, $registrableDomain, $domain)
+    public function testGetPublicSuffix($publicSuffix, $registrableDomain, $domain, $expectedDomain)
     {
         $this->assertSame($publicSuffix, $this->list->query($domain)->getPublicSuffix());
+    }
+
+    /**
+     * @dataProvider parseDataProvider
+     */
+    public function testGetDomain($publicSuffix, $registrableDomain, $domain, $expectedDomain)
+    {
+        $this->assertSame($expectedDomain, $this->list->query($domain)->getDomain());
+    }
+
+    public function parseDataProvider()
+    {
+        return [
+            // public suffix, registrable domain, domain
+            // BEGIN https://github.com/jeremykendall/php-domain-parser/issues/16
+            'com tld' => ['com', 'example.com', 'us.example.com', 'us.example.com'],
+            'na tld' => ['na', 'example.na', 'us.example.na', 'us.example.na'],
+            'us.na tld' => ['us.na', 'example.us.na', 'www.example.us.na', 'www.example.us.na'],
+            'org tld' => ['org', 'example.org', 'us.example.org', 'us.example.org'],
+            'biz tld (1)' => ['biz', 'broken.biz', 'webhop.broken.biz', 'webhop.broken.biz'],
+            'biz tld (2)' => ['webhop.biz', 'broken.webhop.biz', 'www.broken.webhop.biz', 'www.broken.webhop.biz'],
+            // END https://github.com/jeremykendall/php-domain-parser/issues/16
+            // Test ipv6 URL
+            'IP (1)' => [null, null, '[::1]', null],
+            'IP (2)' => [null, null, '[2001:db8:85a3:8d3:1319:8a2e:370:7348]', null],
+            'IP (3)' => [null, null, '[2001:db8:85a3:8d3:1319:8a2e:370:7348]', null],
+            // Test IP address: Fixes #43
+            'IP (4)' => [null, null, '192.168.1.2', null],
+            // Link-local addresses and zone indices
+            'IP (5)' => [null, null, '[fe80::3%25eth0]', null],
+            'IP (6)' => [null, null, '[fe80::1%2511]', null],
+            'fake tld' => ['faketld', 'example.faketld', 'example.faketld', 'example.faketld'],
+        ];
     }
 
     public function testGetPublicSuffixHandlesWrongCaseProperly()
@@ -76,129 +114,14 @@ class PublicSuffixListTest extends TestCase
         $this->assertSame($publicSuffix, $this->list->query($domain)->getPublicSuffix());
     }
 
-    public function testPublicSuffixSpec()
+    /**
+     * @dataProvider publicSuffixSpecProvider
+     * @param  string      $domain
+     * @param  string|null $expected
+     */
+    public function testPublicSuffixSpecification($domain, $expected)
     {
-        // Test data from Rob Stradling at Comodo
-        // http://mxr.mozilla.org/mozilla-central/source/netwerk/test/unit/data/test_psl.txt?raw=1
-        // Any copyright is dedicated to the Public Domain.
-        // http://creativecommons.org/publicdomain/zero/1.0/
-
-        // null input.
-        $this->checkPublicSuffix(null, null);
-        // Mixed case.
-        $this->checkPublicSuffix('COM', null);
-        $this->checkPublicSuffix('example.COM', 'example.com');
-        $this->checkPublicSuffix('WwW.example.COM', 'example.com');
-        // Leading dot.
-        $this->checkPublicSuffix('.com', null);
-        $this->checkPublicSuffix('.example', null);
-        $this->checkPublicSuffix('.example.com', null);
-        $this->checkPublicSuffix('.example.example', null);
-        // Unlisted TLD.
-        // Addresses algorithm rule #2: If no rules match, the prevailing rule is "*".
-        $this->checkPublicSuffix('example', null);
-        $this->checkPublicSuffix('example.example', 'example.example');
-        $this->checkPublicSuffix('b.example.example', 'example.example');
-        $this->checkPublicSuffix('a.b.example.example', 'example.example');
-        // TLD with only 1 rule.
-        $this->checkPublicSuffix('biz', null);
-        $this->checkPublicSuffix('domain.biz', 'domain.biz');
-        $this->checkPublicSuffix('b.domain.biz', 'domain.biz');
-        $this->checkPublicSuffix('a.b.domain.biz', 'domain.biz');
-        // TLD with some 2-level rules.
-        $this->checkPublicSuffix('com', null);
-        $this->checkPublicSuffix('example.com', 'example.com');
-        $this->checkPublicSuffix('b.example.com', 'example.com');
-        $this->checkPublicSuffix('a.b.example.com', 'example.com');
-        $this->checkPublicSuffix('uk.com', null);
-        $this->checkPublicSuffix('example.uk.com', 'example.uk.com');
-        $this->checkPublicSuffix('b.example.uk.com', 'example.uk.com');
-        $this->checkPublicSuffix('a.b.example.uk.com', 'example.uk.com');
-        $this->checkPublicSuffix('test.ac', 'test.ac');
-        // TLD with only 1 (wildcard) rule.
-        $this->checkPublicSuffix('mm', null);
-        $this->checkPublicSuffix('c.mm', null);
-        $this->checkPublicSuffix('b.c.mm', 'b.c.mm');
-        $this->checkPublicSuffix('a.b.c.mm', 'b.c.mm');
-        // More complex TLD.
-        $this->checkPublicSuffix('jp', null);
-        $this->checkPublicSuffix('test.jp', 'test.jp');
-        $this->checkPublicSuffix('www.test.jp', 'test.jp');
-        $this->checkPublicSuffix('ac.jp', null);
-        $this->checkPublicSuffix('test.ac.jp', 'test.ac.jp');
-        $this->checkPublicSuffix('www.test.ac.jp', 'test.ac.jp');
-        $this->checkPublicSuffix('kyoto.jp', null);
-        $this->checkPublicSuffix('test.kyoto.jp', 'test.kyoto.jp');
-        $this->checkPublicSuffix('ide.kyoto.jp', null);
-        $this->checkPublicSuffix('b.ide.kyoto.jp', 'b.ide.kyoto.jp');
-        $this->checkPublicSuffix('a.b.ide.kyoto.jp', 'b.ide.kyoto.jp');
-        $this->checkPublicSuffix('c.kobe.jp', null);
-        $this->checkPublicSuffix('b.c.kobe.jp', 'b.c.kobe.jp');
-        $this->checkPublicSuffix('a.b.c.kobe.jp', 'b.c.kobe.jp');
-        $this->checkPublicSuffix('city.kobe.jp', 'city.kobe.jp');
-        $this->checkPublicSuffix('www.city.kobe.jp', 'city.kobe.jp');
-        // TLD with a wildcard rule and exceptions.
-        $this->checkPublicSuffix('ck', null);
-        $this->checkPublicSuffix('test.ck', null);
-        $this->checkPublicSuffix('b.test.ck', 'b.test.ck');
-        $this->checkPublicSuffix('a.b.test.ck', 'b.test.ck');
-        $this->checkPublicSuffix('www.ck', 'www.ck');
-        $this->checkPublicSuffix('www.www.ck', 'www.ck');
-        // US K12.
-        $this->checkPublicSuffix('us', null);
-        $this->checkPublicSuffix('test.us', 'test.us');
-        $this->checkPublicSuffix('www.test.us', 'test.us');
-        $this->checkPublicSuffix('ak.us', null);
-        $this->checkPublicSuffix('test.ak.us', 'test.ak.us');
-        $this->checkPublicSuffix('www.test.ak.us', 'test.ak.us');
-        $this->checkPublicSuffix('k12.ak.us', null);
-        $this->checkPublicSuffix('test.k12.ak.us', 'test.k12.ak.us');
-        $this->checkPublicSuffix('www.test.k12.ak.us', 'test.k12.ak.us');
-        // IDN labels.
-        $this->checkPublicSuffix('食狮.com.cn', '食狮.com.cn');
-        $this->checkPublicSuffix('食狮.公司.cn', '食狮.公司.cn');
-        $this->checkPublicSuffix('www.食狮.公司.cn', '食狮.公司.cn');
-        $this->checkPublicSuffix('shishi.公司.cn', 'shishi.公司.cn');
-        $this->checkPublicSuffix('公司.cn', null);
-        $this->checkPublicSuffix('食狮.中国', '食狮.中国');
-        $this->checkPublicSuffix('www.食狮.中国', '食狮.中国');
-        $this->checkPublicSuffix('shishi.中国', 'shishi.中国');
-        $this->checkPublicSuffix('中国', null);
-        // Same as above, but punycoded.
-        $this->checkPublicSuffix('xn--85x722f.com.cn', 'xn--85x722f.com.cn');
-        $this->checkPublicSuffix('xn--85x722f.xn--55qx5d.cn', 'xn--85x722f.xn--55qx5d.cn');
-        $this->checkPublicSuffix('www.xn--85x722f.xn--55qx5d.cn', 'xn--85x722f.xn--55qx5d.cn');
-        $this->checkPublicSuffix('shishi.xn--55qx5d.cn', 'shishi.xn--55qx5d.cn');
-        $this->checkPublicSuffix('xn--55qx5d.cn', null);
-        $this->checkPublicSuffix('xn--85x722f.xn--fiqs8s', 'xn--85x722f.xn--fiqs8s');
-        $this->checkPublicSuffix('www.xn--85x722f.xn--fiqs8s', 'xn--85x722f.xn--fiqs8s');
-        $this->checkPublicSuffix('shishi.xn--fiqs8s', 'shishi.xn--fiqs8s');
-        $this->checkPublicSuffix('xn--fiqs8s', null);
-    }
-
-    public function parseDataProvider()
-    {
-        return [
-            // public suffix, registrable domain, domain
-            // BEGIN https://github.com/jeremykendall/php-domain-parser/issues/16
-            ['com', 'example.com', 'us.example.com'],
-            ['na', 'example.na', 'us.example.na'],
-            ['us.na', 'example.us.na', 'www.example.us.na'],
-            ['org', 'example.org', 'us.example.org'],
-            ['biz', 'broken.biz', 'webhop.broken.biz'],
-            ['webhop.biz', 'broken.webhop.biz', 'www.broken.webhop.biz'],
-            // END https://github.com/jeremykendall/php-domain-parser/issues/16
-            // Test ipv6 URL
-            [null, null, '[::1]'],
-            [null, null, '[2001:db8:85a3:8d3:1319:8a2e:370:7348]'],
-            [null, null, '[2001:db8:85a3:8d3:1319:8a2e:370:7348]'],
-            // Test IP address: Fixes #43
-            [null, null, '192.168.1.2'],
-            // Link-local addresses and zone indices
-            [null, null, '[fe80::3%25eth0]'],
-            [null, null, '[fe80::1%2511]'],
-            ['faketld', 'example.faketld', 'example.faketld'],
-        ];
+        $this->checkPublicSuffix($domain, $expected);
     }
 
     /**
@@ -215,9 +138,95 @@ class PublicSuffixListTest extends TestCase
      */
     private function checkPublicSuffix($domain, $expected)
     {
-        $this->assertSame(
-            $expected,
-            $this->list->query($domain)->getRegistrableDomain()
-        );
+        $this->assertSame($expected, $this->list->query($domain)->getRegistrableDomain());
+    }
+
+    public function publicSuffixSpecProvider()
+    {
+        // Test data from Rob Stradling at Comodo
+        // http://mxr.mozilla.org/mozilla-central/source/netwerk/test/unit/data/test_psl.txt?raw=1
+        // Any copyright is dedicated to the Public Domain.
+        // http://creativecommons.org/publicdomain/zero/1.0/
+
+        return [
+            'null' => [null, null],
+            'single label' => ['COM', null],
+            'mixed case (1)' => ['example.COM', 'example.com'],
+            'mixed case (2)' => ['WWW.example.COM', 'example.com'],
+            'leading dot (1)' => ['.com', null],
+            'leading dot (2)' => ['.example', null],
+            'leading dot (3)' => ['.example.com', null],
+            'leading dot (4)' => ['.example.example', null],
+            'unlisted TLD (1)' => ['example', null],
+            'unlisted TLD (2)' => ['example.example', 'example.example'],
+            'unlisted TLD (3)' => ['b.example.example', 'example.example'],
+            'unlisted TLD (4)' => ['a.b.example.example', 'example.example'],
+            'tld with 1 rule (1)' => ['biz', null],
+            'tld with 1 rule (2)' => ['domain.biz', 'domain.biz'],
+            'tld with 1 rule (3)' => ['a.domain.biz', 'domain.biz'],
+            'tld with 1 rule (4)' => ['a.b.domain.biz', 'domain.biz'],
+            'tld with some 2-level rules (1)' => ['com', null],
+            'tld with some 2-level rules (2)' => ['example.com', 'example.com'],
+            'tld with some 2-level rules (3)' => ['a.example.com', 'example.com'],
+            'tld with some 2-level rules (4)' => ['a.b.example.com', 'example.com'],
+            'tld with some 2-level rules (5)' => ['uk.com', null],
+            'tld with some 2-level rules (6)' => ['example.uk.com', 'example.uk.com'],
+            'tld with some 2-level rules (7)' => ['b.example.uk.com', 'example.uk.com'],
+            'tld with some 2-level rules (8)' => ['a.b.example.uk.com', 'example.uk.com'],
+            'tld with some 2-level rules (9)' => ['test.ac', 'test.ac'],
+            'tld with only 1 (wildcard) rule (1)' => ['mm', null],
+            'tld with only 1 (wildcard) rule (2)' => ['c.mm', null],
+            'tld with only 1 (wildcard) rule (3)' => ['b.c.mm', 'b.c.mm'],
+            'tld with only 1 (wildcard) rule (4)' => ['a.b.c.mm', 'b.c.mm'],
+            'more complex tld (1)' => ['jp', null],
+            'more complex tld (2)' => ['test.jp', 'test.jp'],
+            'more complex tld (3)' => ['www.test.jp', 'test.jp'],
+            'more complex tld (4)' => ['ac.jp', null],
+            'more complex tld (5)' => ['test.ac.jp', 'test.ac.jp'],
+            'more complex tld (6)' => ['www.test.ac.jp', 'test.ac.jp'],
+            'more complex tld (7)' => ['kyoto.jp', null],
+            'more complex tld (8)' => ['test.kyoto.jp', 'test.kyoto.jp'],
+            'more complex tld (9)' => ['ide.kyoto.jp', null],
+            'more complex tld (10)' => ['b.ide.kyoto.jp', 'b.ide.kyoto.jp'],
+            'more complex tld (11)' => ['a.b.ide.kyoto.jp', 'b.ide.kyoto.jp'],
+            'more complex tld (12)' => ['c.kobe.jp', null],
+            'more complex tld (13)' => ['b.c.kobe.jp', 'b.c.kobe.jp'],
+            'more complex tld (14)' => ['a.b.c.kobe.jp', 'b.c.kobe.jp'],
+            'more complex tld (15)' => ['city.kobe.jp', 'city.kobe.jp'],
+            'more complex tld (16)' => ['www.city.kobe.jp', 'city.kobe.jp'],
+            'tld with a wildcard rule and exceptions (1)' => ['ck', null],
+            'tld with a wildcard rule and exceptions (2)' => ['test.ck', null],
+            'tld with a wildcard rule and exceptions (3)' => ['b.test.ck', 'b.test.ck'],
+            'tld with a wildcard rule and exceptions (4)' => ['a.b.test.ck', 'b.test.ck'],
+            'tld with a wildcard rule and exceptions (5)' => ['www.ck', 'www.ck'],
+            'tld with a wildcard rule and exceptions (6)' => ['www.www.ck', 'www.ck'],
+            'us k12 (1)' => ['us', null],
+            'us k12 (2)' => ['test.us', 'test.us'],
+            'us k12 (3)' => ['www.test.us', 'test.us'],
+            'us k12 (4)' => ['ak.us', null],
+            'us k12 (5)' => ['test.ak.us', 'test.ak.us'],
+            'us k12 (6)' => ['www.test.ak.us', 'test.ak.us'],
+            'us k12 (7)' => ['k12.ak.us', null],
+            'us k12 (8)' => ['test.k12.ak.us', 'test.k12.ak.us'],
+            'us k12 (9)' => ['www.test.k12.ak.us', 'test.k12.ak.us'],
+            'idn labels (1)' => ['食狮.com.cn', '食狮.com.cn'],
+            'idn labels (2)' => ['食狮.公司.cn', '食狮.公司.cn'],
+            'idn labels (3)' => ['www.食狮.公司.cn', '食狮.公司.cn'],
+            'idn labels (4)' => ['shishi.公司.cn', 'shishi.公司.cn'],
+            'idn labels (5)' => ['公司.cn', null],
+            'idn labels (6)' => ['食狮.中国', '食狮.中国'],
+            'idn labels (7)' => ['www.食狮.中国', '食狮.中国'],
+            'idn labels (8)' => ['shishi.中国', 'shishi.中国'],
+            'idn labels (9)' => ['中国', null],
+            'punycoded labels (1)' => ['xn--85x722f.com.cn', 'xn--85x722f.com.cn'],
+            'punycoded labels (2)' => ['xn--85x722f.xn--55qx5d.cn', 'xn--85x722f.xn--55qx5d.cn'],
+            'punycoded labels (3)' => ['www.xn--85x722f.xn--55qx5d.cn', 'xn--85x722f.xn--55qx5d.cn'],
+            'punycoded labels (4)' => ['shishi.xn--55qx5d.cn', 'shishi.xn--55qx5d.cn'],
+            'punycoded labels (5)' => ['xn--55qx5d.cn', null],
+            'punycoded labels (6)' => ['xn--85x722f.xn--fiqs8s', 'xn--85x722f.xn--fiqs8s'],
+            'punycoded labels (7)' => ['www.xn--85x722f.xn--fiqs8s', 'xn--85x722f.xn--fiqs8s'],
+            'punycoded labels (8)' => ['shishi.xn--fiqs8s', 'shishi.xn--fiqs8s'],
+            'punycoded labels (9)' => ['xn--fiqs8s', null],
+        ];
     }
 }


### PR DESCRIPTION
Decoupling the Rules from the main Public suffix list so that we can for instance load only public suffix list without the private domains.

